### PR TITLE
Add shouldAllowNavigation Prop for Custom WebView Navigation Handling

### DIFF
--- a/src/GameballWidget/index.tsx
+++ b/src/GameballWidget/index.tsx
@@ -7,7 +7,11 @@ import {
   Platform,
   Share,
 } from 'react-native';
-import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import {
+  WebView,
+  type WebViewMessageEvent,
+  type WebViewNavigation,
+} from 'react-native-webview';
 import Modal from 'react-native-modal';
 import styles from './styles';
 const package_json = require('../../package.json');
@@ -16,6 +20,7 @@ interface Props {
   modal?: boolean;
   openDetail?: string;
   hideNavigation?: boolean;
+  shouldAllowNavigation?: (event: WebViewNavigation) => boolean;
 }
 
 interface State {
@@ -146,6 +151,7 @@ class GameballWidget extends React.Component<Props, State> {
         originWhitelist={originWhitelist}
         showsVerticalScrollIndicator={false}
         onMessage={this.onMessage}
+        onShouldStartLoadWithRequest={this.props.shouldAllowNavigation}
         injectedJavaScriptBeforeContentLoaded="
         if (navigator.share == null) {
           navigator.share = (param) => {


### PR DESCRIPTION
### Description
This PR introduces a new prop, `shouldAllowNavigation`, to the `GameballWidget` component. This prop allows developers to handle WebView navigation requests and decide whether to allow or block them based on custom logic. Additionally, it enables performing specific actions, such as redirecting users to a login screen or stopping navigation if certain conditions (e.g., user registration) are not met.

### Changes
1. Added `shouldAllowNavigation` prop to the `GameballWidget` component.
2. Updated the `Props` interface to include the new prop.
3. Modified the WebView implementation to use `shouldAllowNavigation`.
4. Updated the README to document the new prop with examples.

### Purpose
The `shouldAllowNavigation` prop enables developers to:
- Restrict navigation to specific domains.
- Perform custom actions based on navigation events (e.g., redirecting to login if the user is not registered).
- Block navigation under certain conditions.

### Request to Maintainers
Please add documentation for the `shouldAllowNavigation` prop to your official website or documentation portal. This will help developers understand its usage and integrate it effectively into their applications.

### Testing
- Verified that the `shouldAllowNavigation` prop works as intended by passing a callback function and observing WebView behavior.

### Checklist
- [x] Code changes
- [ ] Documentation request
- [ ] Tests (if applicable)

### Related Issues
None.